### PR TITLE
Recommend reST style docstrings for documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,17 @@
 For all Python code, the [PEP-8](https://www.python.org/dev/peps/pep-0008/) style guide should be followed. Use descriptive variable names. Travis CI will be linting for PEP-8.
 
 Include comments when your code is not self-explanatory. [Docstrings](https://www.python.org/dev/peps/pep-0257/) at the beginning of functions and classes are generally a good idea.
+
+For docstrings, reST style formatiing should be used. Here is an example docstring in reST format:
+```
+'''
+This function takes a banana and turns it into an apple.
+ 
+(Some relatively detailed explanation of the class or function)
+ 
+:param banana: The banana to be converted.
+:returns: An apple, converted from a banana. 
+:raises TypeError: Raised when the object passed in is not a banana.
+'''
+```
+The reST format is used because it is clean and easy to read, and PyCharm supports it natively when writing code. Sphinx will also automatically generate HTML documentation with this format.


### PR DESCRIPTION
For some reason GitHub desktop used some kind of dummy 'ntoskrnl' account...ugh...guess I'll just have to use the command line git only from now on. Whatever.